### PR TITLE
Remove import module (collector service) because circular import

### DIFF
--- a/src/spaceone/inventory/manager/collector_manager/plugin_manager.py
+++ b/src/spaceone/inventory/manager/collector_manager/plugin_manager.py
@@ -4,7 +4,6 @@ from spaceone.core.manager import BaseManager
 from spaceone.core.connector.space_connector import SpaceConnector
 
 from spaceone.inventory.error import *
-from spaceone.inventory.service.collector_rule_service import CollectorRuleService
 from spaceone.inventory.manager.collector_rule_manager import CollectorRuleManager
 
 __ALL__ = ['PluginManager']
@@ -163,7 +162,7 @@ class PluginManager(BaseManager):
                 'verb': 'create'
             }
 
-            collector_rule_svc: CollectorRuleService = self.locator.get_service('CollectorRuleService', metadata)
+            collector_rule_svc = self.locator.get_service('CollectorRuleService', metadata)
 
             for collector_rule_params in collector_rules:
                 collector_rule_params.update({


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
fix: remove import module (collector service) because circular import

```
2023-01-17T15:47:27.113Z [ERROR]     (api.py:73) (Error) => 'CloudServiceTypeService' load failed. (reason = cannot import name 'CollectorManager' from partially initialized module 'spaceone.inventory.manager.collector_manager' (most likely due to a circular import) (/usr/local/lib/python3.8/site-packages/spaceone_inventory-1.11.0rc2-py3.8.egg/spaceone/inventory/manager/collector_manager/__init__.py))
	error_code = ERROR_LOCATOR
	status_code = INTERNAL
	message = 'CloudServiceTypeService' load failed. (reason = cannot import name 'CollectorManager' from partially initialized module 'spaceone.inventory.manager.collector_manager' (most likely due to a circular import) (/usr/local/lib/python3.8/site-packages/spaceone_inventory-1.11.0rc2-py3.8.egg/spaceone/inventory/manager/collector_manager/__init__.py))  Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/spaceone/core/locator.py", line 23, in get_service
    service_module = _get_module(package, 'service')
  File "/usr/local/lib/python3.8/site-packages/spaceone/core/locator.py", line 11, in _get_module
    return __import__(f'{package}.{target}', fromlist=[f'{target}'])
  File "/usr/local/lib/python3.8/site-packages/spaceone_inventory-1.11.0rc2-py3.8.egg/spaceone/inventory/service/__init__.py", line 2, in <module>
    from spaceone.inventory.service.collector_service import CollectorService
  File "/usr/local/lib/python3.8/site-packages/spaceone_inventory-1.11.0rc2-py3.8.egg/spaceone/inventory/service/collector_service.py", line 7, in <module>
    from spaceone.inventory.manager.collector_manager import CollectorManager
  File "/usr/local/lib/python3.8/site-packages/spaceone_inventory-1.11.0rc2-py3.8.egg/spaceone/inventory/manager/__init__.py", line 6, in <module>
    from spaceone.inventory.manager.collector_manager.__init__ import *
  File "/usr/local/lib/python3.8/site-packages/spaceone_inventory-1.11.0rc2-py3.8.egg/spaceone/inventory/manager/collector_manager/__init__.py", line 21, in <module>
    from spaceone.inventory.manager.collector_manager.plugin_manager import PluginManager
  File "/usr/local/lib/python3.8/site-packages/spaceone_inventory-1.11.0rc2-py3.8.egg/spaceone/inventory/manager/collector_manager/plugin_manager.py", line 7, in <module>
    from spaceone.inventory.service.collector_rule_service import CollectorRuleService
  File "/usr/local/lib/python3.8/site-packages/spaceone_inventory-1.11.0rc2-py3.8.egg/spaceone/inventory/service/collector_rule_service.py", line 6, in <module>
    from spaceone.inventory.manager.collector_manager import CollectorManager
ImportError: cannot import name 'CollectorManager' from partially initialized module 'spaceone.inventory.manager.collector_manager' (most likely due to a circular import) (/usr/local/lib/python3.8/site-packages/spaceone_inventory-1.11.0rc2-py3.8.egg/spaceone/inventory/manager/collector_manager/__init__.py)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/spaceone/core/pygrpc/api.py", line 98, in wrapper
    response_or_iterator = func(self, request_or_iterator, context)
  File "/usr/local/lib/python3.8/site-packages/spaceone_inventory-1.11.0rc2-py3.8.egg/spaceone/inventory/api/v1/cloud_service_type.py", line 38, in list
    with self.locator.get_service('CloudServiceTypeService', metadata) as cloud_svc_type_service:
  File "/usr/local/lib/python3.8/site-packages/spaceone/core/locator.py", line 33, in get_service
    raise ERROR_LOCATOR(name=name, reason=e, _meta={'type': 'service'})
spaceone.core.error.ERROR_LOCATOR:
	error_code = ERROR_LOCATOR
	status_code = INTERNAL
	message = 'CloudServiceTypeService' load failed. (reason = cannot import name 'CollectorManager' from partially initialized module 'spaceone.inventory.manager.collector_manager' (most likely due to a circular import) (/usr/local/lib/python3.8/site-packages/spaceone_inventory-1.11.0rc2-py3.8.egg/spaceone/inventory/manager/collector_manager/__init__.py))
```

### Known issue
* 