### PR TITLE
Remove trasaction variable used when initializing in connectors

### DIFF
--- a/src/spaceone/inventory/connector/collector_connector.py
+++ b/src/spaceone/inventory/connector/collector_connector.py
@@ -12,8 +12,8 @@ _LOGGER = logging.getLogger(__name__)
 
 class CollectorPluginConnector(BaseConnector):
 
-    def __init__(self, transaction, config):
-        super().__init__(transaction, config)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.client = None
 
     def initialize(self, endpoint):

--- a/src/spaceone/inventory/connector/config_connector.py
+++ b/src/spaceone/inventory/connector/config_connector.py
@@ -18,8 +18,8 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class ConfigConnector(BaseConnector):
-    def __init__(self, transaction, config):
-        super().__init__(transaction, config)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         if 'endpoint' not in self.config:
             raise ERROR_WRONG_CONFIGURATION(key='endpoint')

--- a/src/spaceone/inventory/connector/identity_connector.py
+++ b/src/spaceone/inventory/connector/identity_connector.py
@@ -18,8 +18,8 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class IdentityConnector(BaseConnector):
-    def __init__(self, transaction, config):
-        super().__init__(transaction, config)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         if 'endpoint' not in self.config:
             raise ERROR_WRONG_CONFIGURATION(key='endpoint')

--- a/src/spaceone/inventory/connector/plugin_connector.py
+++ b/src/spaceone/inventory/connector/plugin_connector.py
@@ -15,8 +15,8 @@ _LOGGER = logging.getLogger(__name__)
 
 class PluginConnector(BaseConnector):
 
-    def __init__(self, transaction, config):
-        super().__init__(transaction, config)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self._check_config()
         self._init_client()
 

--- a/src/spaceone/inventory/connector/repository_connector.py
+++ b/src/spaceone/inventory/connector/repository_connector.py
@@ -19,8 +19,8 @@ _LOGGER = logging.getLogger(__name__)
 
 class RepositoryConnector(BaseConnector):
 
-    def __init__(self, transaction, config):
-        super().__init__(transaction, config)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self._check_config()
         self._init_client()
 

--- a/src/spaceone/inventory/connector/secret_connector.py
+++ b/src/spaceone/inventory/connector/secret_connector.py
@@ -15,8 +15,8 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class SecretConnector(BaseConnector):
-    def __init__(self, transaction, config):
-        super().__init__(transaction, config)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         if 'endpoint' not in self.config:
             raise ERROR_WRONG_CONFIGURATION(key='endpoint')


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [x] Refactor
- [ ] etc

### Description
* As the transaction structure of the core framework changes, the transaction variable of the dependent microservice is removed.