### PR TITLE
helm: update version

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -4,6 +4,6 @@ description: SpaceONE inventory Helm chart for Kubernetes
 
 type: application
 
-version: 1.3.15
+version: 1.3.16
 appVersion: 1.x.y
 


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
Updating the helm version because the changes to the Inventory Application Scheduler haven't been reflected.

### Known issue

```bash
k get po
NAME                                       READY   STATUS             RESTARTS       AGE
...
inventory-scheduler-6c589547cd-hfwdg       0/1     CrashLoopBackOff   10 (23s ago)   26m
```

- After checking the logs of the inventory-scheduler pod, it appears that the updated content has not been reflected yet.