### PR TITLE
fix: add rolebinding entries to joined_list only if user exists in user list

### DIFF
--- a/src/spaceone/inventory/manager/metric_manager.py
+++ b/src/spaceone/inventory/manager/metric_manager.py
@@ -816,11 +816,12 @@ class MetricManager(BaseManager):
         # role binding list + user list
         joined_list = []
         for rolebinding in rolebindings_info:
-            user = user_lookup.get(rolebinding['user_id'], {})
-            joined = rolebinding.copy()
-            joined['state'] = user.get('state')
-            joined['auth_type'] = user.get('auth_type')
-            joined_list.append(joined)
+            user = user_lookup.get(rolebinding['user_id'])
+            if user is not None:
+                joined = rolebinding.copy()
+                joined['state'] = user.get('state')
+                joined['auth_type'] = user.get('auth_type')
+                joined_list.append(joined)
 
         # group by keys
         group_by_keys = ['domain_id', 'workspace_id']


### PR DESCRIPTION
### Category
- [ ] New feature
- [v] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
add rolebinding entries to joined_list only if user exists in user list